### PR TITLE
Custom templates- pptx

### DIFF
--- a/LLM_Export/docker/mcpo/tools/file_export_mcp.py
+++ b/LLM_Export/docker/mcpo/tools/file_export_mcp.py
@@ -52,7 +52,7 @@ LOG_FORMAT_ENV = os.getenv(
 )
 
 
-DOCS_TEMPLATE_PATH= os.getenv("DOCS_TEMPLATE_PATH",None)
+DOCS_TEMPLATE_PATH = os.getenv("DOCS_TEMPLATE_PATH", "/rootPath/templates")
 PPTX_TEMPLATE = None
 DOCX_TEMPLATE = None
 XLSX_TEMPLATE = None
@@ -74,10 +74,16 @@ if DOCS_TEMPLATE_PATH and os.path.exists(DOCS_TEMPLATE_PATH):
     if PPTX_TEMPLATE_PATH:
         PPTX_TEMPLATE = Presentation(PPTX_TEMPLATE_PATH)
         logging.info(f"Using PPTX template: {PPTX_TEMPLATE_PATH}")
-    # if DOCX_TEMPLATE_PATH:
-    #     #todo
-    # if XLSX_TEMPLATE_PATH:
-    #     #todo
+    ## next steps    
+    if DOCX_TEMPLATE_PATH:
+        from docx import Document
+        DOCX_TEMPLATE = Document(DOCX_TEMPLATE_PATH)
+        logging.info(f"Using DOCX template: {DOCX_TEMPLATE_PATH}")
+    
+    if XLSX_TEMPLATE_PATH:
+        from openpyxl import load_workbook
+        XLSX_TEMPLATE = load_workbook(XLSX_TEMPLATE_PATH)
+        logging.info(f"Using XLSX template: {XLSX_TEMPLATE_PATH}")
 
 
 


### PR DESCRIPTION
This PR introduces support for custom presentation templates to improve the styling of generated files.
Users can now provide a template during deployment, making the generated presentations visually consistent with a predefined layout.

Main Changes

create_presentation adapted to support custom templates.

Template path provided via environment variable:

Template is read and layout extracted once during initialization.

Behavior when a template is provided:

If the template contains 1 slide → used for all generated content.

If the template contains 2 slides (common in PPTX templates) →

First slide → title

Second slide → content

If the template contains more than 2 slides → only the first two are used; the rest are ignored.

Fallback behavior:

If the template path is invalid or the template has no slides, the system reverts to the existing generation method (no template).