### PR TITLE
Fixed model distraction on OpenAI (missing data node)

### DIFF
--- a/LLM_Export/docker/mcpo/tools/file_export_mcp.py
+++ b/LLM_Export/docker/mcpo/tools/file_export_mcp.py
@@ -1248,12 +1248,12 @@ def _create_raw_file(content: str, filename: str | None, folder_path: str | None
 
 @mcp.tool()
 def create_file(data: dict, persistent: bool = PERSISTENT_FILES) -> dict:
-    """{"format":"pdf","filename":"report.pdf","content":[{"type":"title","text":"..."},{"type":"paragraph","text":"..."}],"title":"..."}
-{"format":"docx","filename":"doc.docx","content":[{"type":"title","text":"..."},{"type":"list","items":[...]}],"title":"..."}
-{"format":"pptx","filename":"slides.pptx","slides_data":[{"title":"...","content":[...],"image_query":"...","image_position":"left|right|top|bottom","image_size":"small|medium|large"}],"title":"..."}
-{"format":"xlsx","filename":"data.xlsx","content":[["Header1","Header2"],["Val1","Val2"]],"title":"..."}
-{"format":"csv","filename":"data.csv","content":[[...]]}
-{"format":"txt|xml|py|etc","filename":"file.ext","content":"string"}"""
+    """ "{"data": {"format":"pdf","filename":"report.pdf","content":[{"type":"title","text":"..."},{"type":"paragraph","text":"..."}],"title":"..."}}
+"{"data": {"format":"docx","filename":"doc.docx","content":[{"type":"title","text":"..."},{"type":"list","items":[...]}],"title":"..."}}
+"{"data": {"format":"pptx","filename":"slides.pptx","slides_data":[{"title":"...","content":[...],"image_query":"...","image_position":"left|right|top|bottom","image_size":"small|medium|large"}],"title":"..."}}
+"{"data": {"format":"xlsx","filename":"data.xlsx","content":[["Header1","Header2"],["Val1","Val2"]],"title":"..."}}
+"{"data": {"format":"csv","filename":"data.csv","content":[[...]]}}
+"{"data": {"format":"txt|xml|py|etc","filename":"file.ext","content":"string"}}"""
     log.debug("Creating file via tool")
     folder_path = _generate_unique_folder()
     format_type = (data.get("format") or "").lower()


### PR DESCRIPTION
This pull requests fixed an issue with native tool calling.
OpenAI Models (tested gpt-5, gpt-4.1) always got distracted by the instruction and send incomplete tool call requests. They missed sending the data node in json so the call failed on MCPO.

Affects:
 - MCPO mode
 - Native function calling only
 - Tested only with OpenAI models.