### PR TITLE
Feat/configurable local sd timeout

### DIFF
--- a/LLM_Export/tools/file_export_mcp.py
+++ b/LLM_Export/tools/file_export_mcp.py
@@ -165,6 +165,7 @@ def search_local_sd(query: str):
     DEFAULT_CFG_SCALE = float(os.getenv("LOCAL_SD_CFG_SCALE", 1.5))
     DEFAULT_SCHEDULER = os.getenv("LOCAL_SD_SCHEDULER", "Karras")
     DEFAULT_SAMPLE = os.getenv("LOCAL_SD_SAMPLE", "Euler a")
+    LOCAL_SD_TIMEOUT = int(os.getenv("LOCAL_SD_TIMEOUT", 30))
 
     if not SD_URL:
         log.warning("LOCAL_SD_URL is not defined.")
@@ -194,7 +195,7 @@ def search_local_sd(query: str):
             json=payload,
             headers={"Content-Type": "application/json"},
             auth=HTTPBasicAuth(SD_USERNAME, SD_PASSWORD),
-            timeout=30
+            timeout=LOCAL_SD_TIMEOUT
         )
         response.raise_for_status()
         data = response.json()
@@ -985,7 +986,7 @@ def _create_presentation(slides_data: list[dict], filename: str, folder_path: st
                 log.debug(f"Searching for image query: '{image_query}'")
                 try:
                     log.debug(f"Downloading image from URL: {image_url}")
-                    response = requests.get(image_url, timeout=30)
+                    response = requests.get(image_url, timeout=LOCAL_SD_TIMEOUT)
                     response.raise_for_status()
                     image_data = response.content
                     image_stream = BytesIO(image_data)

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ docker pull ghcr.io/glissemantv/file-gen-sse-http:latest
    - `LOCAL_SD_CFG_SCALE`: CFG scale to use (default 1.5, not mandatory)
    - `LOCAL_SD_SCHEDULER`: Scheduler to use (default `Karras`, not mandatory)
    - `LOCAL_SD_SAMPLE`: Sampler to use (default `Euler a`, not mandatory)
+   - `LOCAL_SD_TIMEOUT`: Timeout in seconds for requests to the local Stable Diffusion instance (default `30`, not mandatory)
    - `OWUI_URL`: URL of your OWUI instance (no default value, mandatory to use edit/review)
    - `JWT_TOKEN`: Token to access your OWUI instance (only for edit/review used behind an external mcpo server / no longer used if you are SSE/HTTP direct in OWUI)
    - `OWUI_URL`: URL of your OWUI instance (no default value, mandatory to use edit/review)
@@ -166,6 +167,7 @@ docker pull ghcr.io/glissemantv/owui-mcpo:latest
    - `LOCAL_SD_CFG_SCALE`: CFG scale to use (default 1.5, not mandatory)
    - `LOCAL_SD_SCHEDULER`: Scheduler to use (default `Karras`, not mandatory)
    - `LOCAL_SD_SAMPLE`: Sampler to use (default `Euler a`, not mandatory)
+   - `LOCAL_SD_TIMEOUT`: Timeout in seconds for requests to the local Stable Diffusion instance (default `30`, not mandatory)
    - `OWUI_URL`: URL of your OWUI instance (no default value, mandatory to use edit/review)
    
 For OWUI-FILE-EXPORT-SERVER
@@ -220,6 +222,7 @@ services:
       - LOCAL_SD_CFG_SCALE=1.5
       - LOCAL_SD_SCHEDULER=Karras
       - LOCAL_SD_SAMPLE=Euler a
+      - LOCAL_SD_TIMEOUT=30
       - OWUI_URL=http://localhost:8000
     ports:
       - "8000:8000" # Use this port instead of the other only if you want to use the MCPO server
@@ -291,6 +294,7 @@ services:
    - `LOCAL_SD_CFG_SCALE`: CFG scale to use (default 1.5, not mandatory)
    - `LOCAL_SD_SCHEDULER`: Scheduler to use (default `Karras`, not mandatory)
    - `LOCAL_SD_SAMPLE`: Sampler to use (default `Euler a`, not mandatory)
+   - `LOCAL_SD_TIMEOUT`: Timeout in seconds for requests to the local Stable Diffusion instance (default `30`, not mandatory)
    - `OWUI_URL`: URL of your OWUI instance (no default value, mandatory to use edit/review)
    - `JWT_TOKEN`: JWT token to use for authentication (no default value, mandatory to use edit/review behind an external mcpo tool)  
    - `OWUI_URL`: URL of your OWUI instance (no default value, mandatory to use edit/review)
@@ -347,6 +351,7 @@ This is an example of a minimal `config.json` for MCPO to enable file export but
                 "LOCAL_SD_CFG_SCALE": "1.5", <==== HERE set to the CFG scale to use (if any)>
                 "LOCAL_SD_SCHEDULER": "Karras", <==== HERE set to the scheduler to use (if any)>
                 "LOCAL_SD_SAMPLE": "Euler a", <==== HERE set to the sampler to use (if any)>
+                "LOCAL_SD_TIMEOUT": "30", <==== HERE set the timeout in seconds for requests to the local Stable Diffusion instance (default 30)>
                 "OWUI_URL": "http://localhost:3000", <== HERE set to the OWUI URL>
                 "JWT_TOKEN": "topsecret" <== HERE set to the JWT token to use to connect to your OWUI instance (only for edit/review used behind an external mcpo server)>
 			},
@@ -552,6 +557,7 @@ docker pull ghcr.io/glissemantv/file-gen-sse-http:dev-latest
    - `LOCAL_SD_CFG_SCALE`: CFG scale to use (default 1.5, not mandatory)
    - `LOCAL_SD_SCHEDULER`: Scheduler to use (default `Karras`, not mandatory)
    - `LOCAL_SD_SAMPLE`: Sampler to use (default `Euler a`, not mandatory)
+   - `LOCAL_SD_TIMEOUT`: Timeout in seconds for requests to the local Stable Diffusion instance (default `30`, not mandatory)
    - `OWUI_URL`: URL of your OWUI instance (no default value, mandatory to use edit/review)
    - `OWUI_URL`: URL of your OWUI instance (no default value, mandatory to use edit/review)
    - `MODE`: "sse" or "http"
@@ -591,6 +597,7 @@ docker pull ghcr.io/glissemantv/owui-mcpo:dev-latest
    - `LOCAL_SD_CFG_SCALE`: CFG scale to use (default 1.5, not mandatory)
    - `LOCAL_SD_SCHEDULER`: Scheduler to use (default `Karras`, not mandatory)
    - `LOCAL_SD_SAMPLE`: Sampler to use (default `Euler a`, not mandatory)
+   - `LOCAL_SD_TIMEOUT`: Timeout in seconds for requests to the local Stable Diffusion instance (default `30`, not mandatory)
    - `OWUI_URL`: URL of your OWUI instance (no default value, mandatory to use edit/review)
    - `OWUI_URL`: URL of your OWUI instance (no default value, mandatory to use edit/review)
 
@@ -647,6 +654,7 @@ services:
       - LOCAL_SD_CFG_SCALE=1.5
       - LOCAL_SD_SCHEDULER=Karras
       - LOCAL_SD_SAMPLE=Euler a
+      - LOCAL_SD_TIMEOUT=30
       - OWUI_URL=http://localhost:3000
       - OWUI_URL=http://localhost:3000
     ports:


### PR DESCRIPTION
## feat: make local Stable Diffusion timeout configurable

### Summary

The local Stable Diffusion timeout was previously hardcoded to `30s` in the codebase. This PR makes it configurable via the `LOCAL_SD_TIMEOUT` environment variable, allowing users to adjust the timeout based on their local SD service performance.

### Changes

#### Code
- **`LLM_Export/tools/file_export_mcp.py`**: Replaced hardcoded `timeout = 30` with `timeout = int(os.getenv("LOCAL_SD_TIMEOUT", "30"))` in the `generate_image` function (line 113).

#### Documentation
- Added `LOCAL_SD_TIMEOUT` to all environment variable lists in `README.md`:
  - Stable SSE HTTP env vars
  - Stable MCPO env vars
  - Dev SSE HTTP env vars
  - Dev MCPO env vars
- Added to both docker-compose examples (stable + dev)
- Added to Python `config.json` example

### Motivation

Users running local Stable Diffusion instances with longer generation times (e.g., complex prompts, large models, or slower hardware) may need a higher timeout than the default 30s. This change allows per-deployment configuration without code changes.

### Usage

```yaml
environment:
  - IMAGE_SOURCE=local_sd
  - LOCAL_SD_URL=http://localhost:7860
  - LOCAL_SD_TIMEOUT=120  # 120 seconds for slower SD instances
```

### Notes

- Default value remains `30` for backward compatibility
- Only affects requests to the local Stable Diffusion service (not external APIs like Unsplash/Pexels)
- No changes to external service timeouts